### PR TITLE
Fix PLA/PLX/PLY not setting N and Z flags

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -298,6 +298,7 @@ impl W65C02S {
         self.spurious_stack_read(system);
         self.check_irq_edge();
         self.a = self.pop(system);
+        self.nz_p(self.a);
     }
     pub(crate) fn phx<S: System>(&mut self, system: &mut S) {
         system.read_operand_spurious(self, self.pc);
@@ -309,6 +310,7 @@ impl W65C02S {
         self.spurious_stack_read(system);
         self.check_irq_edge();
         self.x = self.pop(system);
+        self.nz_p(self.x);
     }
     pub(crate) fn phy<S: System>(&mut self, system: &mut S) {
         system.read_operand_spurious(self, self.pc);
@@ -320,6 +322,7 @@ impl W65C02S {
         self.spurious_stack_read(system);
         self.check_irq_edge();
         self.y = self.pop(system);
+        self.nz_p(self.y);
     }
     pub(crate) fn tax<S: System>(&mut self, system: &mut S) {
         self.check_irq_edge();


### PR DESCRIPTION
The PLA, PLX, and PLY instructions were not updating the N and Z processor status flags after popping a value from the stack. These instructions should set flags based on the value loaded, matching the behavior of LDA/LDX/LDY.

This bug caused issues with software that relied on the Z flag being set after pulling a zero value.